### PR TITLE
Add command sync mode for CI pipelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,10 @@ The `ROLE_REWARDS` variable uses the format `level:role_id` separated by commas.
 Commands are automatically synced every time the bot starts. If `GUILD_ID` is
 set, commands sync instantly for that server; otherwise they sync globally.
 See the `bot.py` file for further usage instructions.
+
+To sync the slash commands without starting the bot (useful for Railway's
+pre-deploy step), run:
+
+```
+python bot.py --sync
+```


### PR DESCRIPTION
## Summary
- add `--sync` flag to allow one-off command synchronization
- document how to use the new flag in Railway pre-deploy steps

## Testing
- `python -m py_compile bot.py badges.py leveling.py rank_card.py`

------
https://chatgpt.com/codex/tasks/task_e_685d44a4d820833397b85f39380a345e